### PR TITLE
fix: add lunarvim-support

### DIFF
--- a/run_vim.go
+++ b/run_vim.go
@@ -10,7 +10,14 @@ import (
 )
 
 func isNeovimPath(vimpath string) bool {
-	return strings.HasSuffix(vimpath, "nvim") || strings.HasSuffix(vimpath, "nvim.exe")
+	suff := strings.TrimSuffix(vimpath, ".exe")
+	if strings.HasSuffix(suff, "nvim") {
+		return true
+	}
+	if strings.HasSuffix(suff, "lvim") {
+		return true
+	}
+	return false
 }
 
 func runVim(vimpath string, extra []string, args ...string) error {


### PR DESCRIPTION
This adds support for [LunarVim](https://www.lunarvim.org/), which is using NeoVim, but by default they use their own binary `lvim` instead of `nvim` so that one can use LunarVim without it interfering with NeoVim.

Another option for enabling this compatibility is to add a new flag, for instance `-no-default-args`, which does not inject any arguments on its own, and then let the user supply the relevant flags themselves. I'd be more than willing to add this flag, if this is a route your are more comfortable with, or believe will help.

---

I really like this small utility, and thank you for creating it. 