### PR TITLE
add -e flag when vimpath is vim.exe

### DIFF
--- a/run_vim.go
+++ b/run_vim.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -27,6 +28,13 @@ func runVim(vimpath string, extra []string, args ...string) error {
 		a = append(a, "--headless")
 	} else {
 		a = append(a, "--not-a-term")
+	}
+	if runtime.GOOS == "windows" {
+		if p, err := exec.LookPath(vimpath); err == nil {
+			if filepath.Base(p) == "vim.exe" {
+				a = append(a, "-e")
+			}
+		}
 	}
 	a = append(a, "-c", "qall!")
 	a = append(a, args...)


### PR DESCRIPTION
If `-vimpath vim` is set, vim.exe never quit. Probably, vim.exe does not safe for closed stdout.